### PR TITLE
Update Auth credentials for SDK

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory
 
 import com.netflix.ice.common.IceOptions
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.auth.InstanceProfileCredentialsProvider
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.google.common.collect.Lists
 import com.netflix.ice.tag.Account
 import com.netflix.ice.tag.Region
@@ -81,7 +81,7 @@ class BootStrap {
 			Properties tagProp = getProperties("tag.propertiesfile", "tag.properties");
 			
             if (StringUtils.isEmpty(System.getProperty("ice.s3AccessKeyId")) || StringUtils.isEmpty(System.getProperty("ice.s3SecretKey")))
-                credentialsProvider = new InstanceProfileCredentialsProvider();
+                credentialsProvider = new DefaultAWSCredentialsProviderChain();
             else
                 credentialsProvider = new AWSCredentialsProvider() {
                         public AWSCredentials getCredentials() {
@@ -338,4 +338,3 @@ class BootStrap {
 		return subProperties;
 	}
 }
-	


### PR DESCRIPTION
This update allows use of all auth credential mechanisms that the SDK
supports. ~/.aws/credentials, env variables, etc.  This is necessary for
deployments on ECS, Kubernetes, and others.