### PR TITLE
Properly parse the JSON additionalArtifactKeys

### DIFF
--- a/src/java/com/netflix/ice/processor/CostAndUsageReport.java
+++ b/src/java/com/netflix/ice/processor/CostAndUsageReport.java
@@ -96,6 +96,11 @@ public class CostAndUsageReport extends MonthlyReport {
 		public String name;
 	}
 	
+	public class AdditionalArtifact {
+		public String artifactType;
+		public String name;
+	}
+	
 	public class BillingPeriod {
 		public String start;
 		public String end;
@@ -113,7 +118,7 @@ public class CostAndUsageReport extends MonthlyReport {
 		public BillingPeriod billingPeriod;
 		public String bucket;
 		public String[] reportKeys;
-		public String[] additionalArtifactKeys;
+		public AdditionalArtifact[] additionalArtifactKeys;
 		
 		public boolean hasTags() {
 			for (Column column: columns) {


### PR DESCRIPTION
Parsing fails when it is an array of strings.
"additionalArtifactKeys":[{"artifactType":"QuicksightManifest","name":"QuickSight/cost_report_hourly_gzip-20210501-20210601-QuickSightManifest.json"},{"artifactType":"RedshiftCommands","name":"20210501-20210601/20210809T193620Z/cost_report_hourly_gzip-RedshiftCommands.sql"},{"artifactType":"RedshiftManifest","name":"20210501-20210601/20210809T193620Z/cost_report_hourly_gzip-RedshiftManifest.json"}]